### PR TITLE
Report for Golang errors

### DIFF
--- a/app/badTestFile.go
+++ b/app/badTestFile.go
@@ -1,0 +1,30 @@
+package main
+
+import "fmt"
+
+import (
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+
+	// Harcoded credentials
+
+	username := "admin"
+	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+	fmt.Println("Doing something with: ", username, password)
+
+	// SampleCodeG102 code snippet for network binding
+	l, err := net.Listen("tcp", "0.0.0.0:2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	// Changing file permissions of important files
+	os.Chmod("/etc/passwd", 0777)
+	os.Chmod("~/.bashrc", 0777)
+
+}


### PR DESCRIPTION
Right now if you use Gosec to scan invalid go file and if you report the result in a text, JSON, CSV or another file format you will always receive 0 issues.
The reason for that is that Gosec can't parse the AST of invalid go files and thus will not report anything.

The real problem here is that the user will never know about the issue if he generates the output in a file.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>